### PR TITLE
Avoid divide by zero

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7
+  - 1.11
 
 before_install:
 - go get -u github.com/axw/gocov/gocov

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ which are also included in this library.
 This requires
 
 * git
-* go 1.3+
+* go 1.11+
 
 
 ## Installation

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/bitgoin/lyra2rev2
+
+go 1.13
+
+require (
+	github.com/aead/skein v0.0.0-20160722084837-9365ae6e95d2
+	github.com/dchest/blake256 v1.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/aead/skein v0.0.0-20160722084837-9365ae6e95d2 h1:q5TSngwXJdajCyZPQR+eKyRRgI3/ZXC/Nq1ZxZ4Zxu8=
+github.com/aead/skein v0.0.0-20160722084837-9365ae6e95d2/go.mod h1:4JBZEId5BaLqvA2DGU53phvwkn2WpeLhNSF79/uKBPs=
+github.com/dchest/blake256 v1.1.0 h1:4AuEhGPT/3TTKFhTfBpZ8hgZE7wJpawcYaEawwsbtqM=
+github.com/dchest/blake256 v1.1.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=

--- a/lyra2.go
+++ b/lyra2.go
@@ -574,7 +574,7 @@ func lyra2(k []byte, pwd []byte, salt []byte, timeCost uint64, nRows int, nCols 
 			//Selects a pseudorandom index row*
 			//------------------------------------------------------------------------------------------
 			//rowa = ((unsigned int)state[0]) & (nRows-1);	//(USE THIS IF nRows IS A POWER OF 2)
-			rowa = state[0] % uint64(nRows) //(USE THIS FOR THE "GENERIC" CASE)
+			rowa = state[0] & uint64(nRows - 1) //(USE THIS FOR THE "GENERIC" CASE)
 			//------------------------------------------------------------------------------------------
 
 			//Performs a reduced-round duplexing operation over M[row*] XOR M[prev], updating both M[row*] and M[row]
@@ -586,7 +586,7 @@ func lyra2(k []byte, pwd []byte, salt []byte, timeCost uint64, nRows int, nCols 
 			//updates row: goes to the next row to be computed
 			//------------------------------------------------------------------------------------------
 			//row = (row + step) & (nRows-1);	//(USE THIS IF nRows IS A POWER OF 2)
-			row = (row + step) % nRows //(USE THIS FOR THE "GENERIC" CASE)
+			row = (row + step) & (nRows - 1) //(USE THIS FOR THE "GENERIC" CASE)
 			//------------------------------------------------------------------------------------------
 		}
 	}


### PR DESCRIPTION
If timecost> 1, division by zero may cause an error.